### PR TITLE
Update aws-refarch-wordpress-04-web.yaml

### DIFF
--- a/templates/aws-refarch-wordpress-04-web.yaml
+++ b/templates/aws-refarch-wordpress-04-web.yaml
@@ -127,7 +127,7 @@ Parameters:
     Description: The Amazon RDS master database name.
     Type: String
   ElasticFileSystem:
-    AllowedPattern: ^(fs-)([a-z0-9]{8})$
+    AllowedPattern: ^(fs-)([a-z0-9]{17})$
     Description: The Amazon EFS file system id.
     Type: String
   EC2KeyName:


### PR DESCRIPTION
EFS Current ID format has changed since October 2021
to identifier plus 17-character ID

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
