### PR TITLE
Migrate to EC2 LaunchTemplate

### DIFF
--- a/templates/aws-refarch-wordpress-03-bastion.yaml
+++ b/templates/aws-refarch-wordpress-03-bastion.yaml
@@ -60,7 +60,7 @@ Parameters:
     - 6
     Default: 3
     Description: Number of subnets. This must match your selections in the list of subnets below.
-    Type: String 
+    Type: String
   Subnet:
     Description: Select existing subnets. The number selected must match the number of subnets above. Subnets selected must be in separate AZs.
     Type: List<AWS::EC2::Subnet::Id>
@@ -146,7 +146,9 @@ Resources:
       Cooldown: 60
       HealthCheckGracePeriod: 120
       HealthCheckType: EC2
-      LaunchConfigurationName: !Ref BastionLaunchConfiguration
+      LaunchTemplate:
+        LaunchTemplateId: !Ref BastionLaunchTemplate
+        Version: !GetAtt BastionLaunchTemplate.LatestVersionNumber
       MaxSize: 1
       MinSize: 0
       Tags:
@@ -175,16 +177,19 @@ Resources:
               ]
             ]
           ]
-  BastionLaunchConfiguration:
-    Type: AWS::AutoScaling::LaunchConfiguration
+  BastionLaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
     Properties:
-      IamInstanceProfile: !Ref BastionInstanceProfile
-      ImageId: !FindInMap [ RegionMap, !Ref 'AWS::Region', AMI ]
-      InstanceMonitoring: true
-      InstanceType: !Ref BastionInstanceType
-      KeyName: !Ref EC2KeyName
-      SecurityGroups:
-        - !Ref BastionSecurityGroup
+      LaunchTemplateData:
+        IamInstanceProfile:
+          Name: !Ref BastionInstanceProfile
+        ImageId: !FindInMap [ RegionMap, !Ref 'AWS::Region', AMI ]
+        Monitoring:
+          Enabled: true
+        InstanceType: !Ref BastionInstanceType
+        KeyName: !Ref EC2KeyName
+        SecurityGroupIds:
+          - !Ref BastionSecurityGroup
   BastionInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:

--- a/templates/aws-refarch-wordpress-03-efsalarms.yaml
+++ b/templates/aws-refarch-wordpress-03-efsalarms.yaml
@@ -177,7 +177,9 @@ Resources:
       Cooldown: 60
       HealthCheckGracePeriod: 120
       HealthCheckType: EC2
-      LaunchConfigurationName: !Ref LaunchConfiguration
+      LaunchTemplate:
+        LaunchTemplateId: !Ref LaunchTemplate
+        Version: !GetAtt LaunchTemplate.LatestVersionNumber
       MaxSize: 1
       MinSize: 0
       DesiredCapacity: 1
@@ -314,8 +316,8 @@ Resources:
             Action:
               - sns:Publish
             Resource: !Ref SNSTopic
-  LaunchConfiguration:
-    Type: AWS::AutoScaling::LaunchConfiguration
+  LaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
     DependsOn: WarningAlarm
     Metadata:
       AWS::CloudFormation::Init:
@@ -425,22 +427,24 @@ Resources:
               owner: root
               group: root             
     Properties:
-      BlockDeviceMappings:
-        - DeviceName: /dev/xvda
-          Ebs:
+      LaunchTemplateData:
+        BlockDeviceMappings:
+          - DeviceName: /dev/xvda
+            Ebs:
             DeleteOnTermination: true
             VolumeSize: 10
             VolumeType: gp2
-      IamInstanceProfile: !Ref InstanceProfile
-      ImageId: !FindInMap [ RegionMap, !Ref 'AWS::Region', AMI ]
-      InstanceMonitoring: true
-      InstanceType: !Ref InstanceType
-      KeyName: !Ref EC2KeyName
-      SecurityGroups:
-      - !Ref SecurityGroup
-      UserData:
-        "Fn::Base64":
-          !Sub |
+        IamInstanceProfile:
+          Name: !Ref InstanceProfile
+        ImageId: !FindInMap [ RegionMap, !Ref 'AWS::Region', AMI ]
+        Monitoring:
+          Enabled: true
+        InstanceType: !Ref InstanceType
+        KeyName: !Ref EC2KeyName
+        SecurityGroupIds:
+          - !Ref SecurityGroup
+        UserData:
+          "Fn::Base64": !Sub |
             #cloud-config
             repo_update: true
             repo_upgrade: all

--- a/templates/aws-refarch-wordpress-03-efsfilesystem.yaml
+++ b/templates/aws-refarch-wordpress-03-efsfilesystem.yaml
@@ -336,7 +336,9 @@ Resources:
       Cooldown: 60
       HealthCheckGracePeriod: 120
       HealthCheckType: EC2
-      LaunchConfigurationName: !Ref LaunchConfiguration
+      LaunchTemplate:
+        LaunchTemplateId: !Ref LaunchTemplate
+        Version: !GetAtt LaunchTemplate.LatestVersionNumber
       MaxSize: 1
       MinSize: 0
       DesiredCapacity: 1
@@ -381,8 +383,8 @@ Resources:
       Cooldown: 60
       PolicyType: SimpleScaling
       ScalingAdjustment: 1
-  LaunchConfiguration:
-    Type: AWS::AutoScaling::LaunchConfiguration
+  LaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
     Metadata:
       AWS::CloudFormation::Init:
         configSets:
@@ -481,37 +483,40 @@ Resources:
               owner: root
               group: root
     Properties:
-      BlockDeviceMappings:
-        - DeviceName: /dev/xvda
-          Ebs:
-            DeleteOnTermination: true
-            VolumeSize: 10
-            VolumeType: gp2
-      IamInstanceProfile: !Ref InstanceProfile
-      ImageId: !FindInMap [ RegionMap, !Ref 'AWS::Region', AMI ]
-      InstanceMonitoring: true
-      InstanceType: !Ref InstanceType
-      KeyName: !Ref EC2KeyName
-      SecurityGroups:
-      - !Ref SecurityGroup
-      UserData:
-        "Fn::Base64":
-          !Join [
-            "",[
-            "#cloud-config\n",
-            "repo_update: true\n",
-            "repo_upgrade: all\n",
-            "\n",
-            "packages:\n",
-            "- parallel\n",
-            "\n",
-            "runcmd:\n",
-            "- yum --enablerepo=epel install nload -y\n",
-            "- ntpstat\n",
-            "- /opt/aws/bin/cfn-init --configsets efs_add_storage --verbose --stack ", !Ref 'AWS::StackName', " --resource LaunchConfiguration --region ", !Ref 'AWS::Region',"\n",
-            "- /opt/aws/bin/cfn-signal -e $? --stack ", !Ref 'AWS::StackName', " --resource AutoScalingGroup --region ", !Ref 'AWS::Region',"\n"
+      LaunchTemplateData:
+        BlockDeviceMappings:
+          - DeviceName: /dev/xvda
+            Ebs:
+              DeleteOnTermination: true
+              VolumeSize: 10
+              VolumeType: gp2
+        IamInstanceProfile:
+          Name: !Ref InstanceProfile
+        ImageId: !FindInMap [ RegionMap, !Ref 'AWS::Region', AMI ]
+        Monitoring:
+          Enabled: true
+        InstanceType: !Ref InstanceType
+        KeyName: !Ref EC2KeyName
+        SecurityGroupIds:
+          - !Ref SecurityGroup
+        UserData:
+          "Fn::Base64":
+            !Join [
+              "",[
+              "#cloud-config\n",
+              "repo_update: true\n",
+              "repo_upgrade: all\n",
+              "\n",
+              "packages:\n",
+              "- parallel\n",
+              "\n",
+              "runcmd:\n",
+              "- yum --enablerepo=epel install nload -y\n",
+              "- ntpstat\n",
+              "- /opt/aws/bin/cfn-init --configsets efs_add_storage --verbose --stack ", !Ref 'AWS::StackName', " --resource LaunchConfiguration --region ", !Ref 'AWS::Region',"\n",
+              "- /opt/aws/bin/cfn-signal -e $? --stack ", !Ref 'AWS::StackName', " --resource AutoScalingGroup --region ", !Ref 'AWS::Region',"\n"
+              ]
             ]
-          ]
   EfsSizeMonitorFunction:
     Type: AWS::Lambda::Function
     Properties: 

--- a/templates/aws-refarch-wordpress-04-web.yaml
+++ b/templates/aws-refarch-wordpress-04-web.yaml
@@ -365,15 +365,24 @@ Resources:
       Cooldown: 60
       HealthCheckGracePeriod: 120
       HealthCheckType: ELB
-      LaunchConfigurationName:
-        !If
+      LaunchTemplate:
+        LaunchTemplateId: !If
           [ PHP80,
-          !Ref WebLaunchConfiguration80,
-          !If
-            [ PHP56,
-            !Ref WebLaunchConfiguration56,
-            !Ref WebLaunchConfiguration70
-            ]          
+            !Ref WebLaunchTemplate80,
+            !If [
+              PHP56,
+              !Ref WebLaunchTemplate56,
+              !Ref WebLaunchTemplate70
+              ]
+            ]
+        Version: !If
+          [ PHP80,
+            !GetAtt WebLaunchTemplate80.LatestVersionNumber,
+            !If [
+              PHP56,
+              !GetAtt WebLaunchTemplate56.LatestVersionNumber,
+              !GetAtt WebLaunchTemplate70.LatestVersionNumber,
+            ]
           ]
       MaxSize: !Ref WebAsgMax
       MinSize: !Ref WebAsgMin
@@ -409,9 +418,9 @@ Resources:
       ResourceSignal:
         Count: !Ref WebAsgMin
         Timeout: PT60M
-  WebLaunchConfiguration80:
+  WebLaunchTemplate80:
     Condition: PHP80
-    Type: AWS::AutoScaling::LaunchConfiguration
+    Type: AWS::EC2::LaunchTemplate
     Metadata:
       AWS::CloudFormation::Init:
         configSets:
@@ -605,16 +614,18 @@ Resources:
                 enabled: true
                 ensureRunning: true
     Properties:
-      IamInstanceProfile: !Ref WebInstanceProfile
-      ImageId: !FindInMap [ RegionMap, !Ref 'AWS::Region', AMI ]
-      InstanceMonitoring: true
-      InstanceType: !Ref WebInstanceType
-      KeyName: !Ref EC2KeyName
-      SecurityGroups:
-      - !Ref WebSecurityGroup
-      UserData:
-        "Fn::Base64":
-          !Sub |
+      LaunchTemplateData:
+        IamInstanceProfile:
+          Name: !Ref WebInstanceProfile
+        ImageId: !FindInMap [ RegionMap, !Ref 'AWS::Region', AMI ]
+        Monitoring:
+          Enabled: true
+        InstanceType: !Ref WebInstanceType
+        KeyName: !Ref EC2KeyName
+        SecurityGroupIds:
+          - !Ref WebSecurityGroup
+        UserData:
+          "Fn::Base64": !Sub |
             #!/bin/bash -xe
             yum update -y
             amazon-linux-extras enable php8.0
@@ -623,9 +634,9 @@ Resources:
             mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 ${ElasticFileSystem}.efs.${AWS::Region}.amazonaws.com:/ /var/www/wordpress
             /opt/aws/bin/cfn-init --configsets deploy_webserver --verbose --stack ${AWS::StackName} --resource WebLaunchConfiguration80 --region ${AWS::Region}
             /opt/aws/bin/cfn-signal --exit-code $? --stack ${AWS::StackName} --resource WebAutoScalingGroup --region ${AWS::Region}
-  WebLaunchConfiguration56:
+  WebLaunchTemplate56:
     Condition: PHP56
-    Type: AWS::AutoScaling::LaunchConfiguration
+    Type: AWS::EC2::LaunchTemplate
     Metadata:
       AWS::CloudFormation::Init:
         configSets:
@@ -815,25 +826,27 @@ Resources:
                 enabled: true
                 ensureRunning: true
     Properties:
-      IamInstanceProfile: !Ref WebInstanceProfile
-      ImageId: !FindInMap [ RegionMap, !Ref 'AWS::Region', AMI ]
-      InstanceMonitoring: true
-      InstanceType: !Ref WebInstanceType
-      KeyName: !Ref EC2KeyName
-      SecurityGroups:
-      - !Ref WebSecurityGroup
-      UserData:
-        "Fn::Base64":
-          !Sub |
+      LaunchTemplateData:
+        IamInstanceProfile:
+          Name: !Ref WebInstanceProfile
+        ImageId: !FindInMap [ RegionMap, !Ref 'AWS::Region', AMI ]
+        Monitoring:
+          Enabled: true
+        InstanceType: !Ref WebInstanceType
+        KeyName: !Ref EC2KeyName
+        SecurityGroupIds:
+          - !Ref WebSecurityGroup
+        UserData:
+          "Fn::Base64": !Sub |
             #!/bin/bash -xe
             yum update -y
             mkdir -p /var/www/wordpress
             mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 ${ElasticFileSystem}.efs.${AWS::Region}.amazonaws.com:/ /var/www/wordpress
             /opt/aws/bin/cfn-init --configsets deploy_webserver --verbose --stack ${AWS::StackName} --resource WebLaunchConfiguration56 --region ${AWS::Region}
             /opt/aws/bin/cfn-signal --exit-code $? --stack ${AWS::StackName} --resource WebAutoScalingGroup --region ${AWS::Region}
-  WebLaunchConfiguration70:
+  WebLaunchTemplate70:
     Condition: PHP70
-    Type: AWS::AutoScaling::LaunchConfiguration
+    Type: AWS::EC2::LaunchTemplate
     Metadata:
       AWS::CloudFormation::Init:
         configSets:
@@ -1024,16 +1037,18 @@ Resources:
                 enabled: true
                 ensureRunning: true
     Properties:
-      IamInstanceProfile: !Ref WebInstanceProfile
-      ImageId: !FindInMap [ RegionMap, !Ref 'AWS::Region', AMI ]
-      InstanceMonitoring: true
-      InstanceType: !Ref WebInstanceType
-      KeyName: !Ref EC2KeyName
-      SecurityGroups:
-      - !Ref WebSecurityGroup
-      UserData:
-        "Fn::Base64":
-          !Sub |
+      LaunchTemplateData:
+        IamInstanceProfile:
+          Name: !Ref WebInstanceProfile
+        ImageId: !FindInMap [ RegionMap, !Ref 'AWS::Region', AMI ]
+        Monitoring:
+          Enabled: true
+        InstanceType: !Ref WebInstanceType
+        KeyName: !Ref EC2KeyName
+        SecurityGroupIds:
+          - !Ref WebSecurityGroup
+        UserData:
+          "Fn::Base64": !Sub |
             #!/bin/bash -xe
             yum update -y
             mkdir -p /var/www/wordpress


### PR DESCRIPTION
I got an email from AWS saying launch configurations are deprecated. No new features or instance types will be available after December 31st, 2022. New accounts won't allow creating launch configurations after December 31st, 2023.
