### PR TITLE
Fix missing carriage return in create_site_conf.sh script

### DIFF
--- a/templates/aws-refarch-wordpress-04-web.yaml
+++ b/templates/aws-refarch-wordpress-04-web.yaml
@@ -438,9 +438,9 @@ Resources:
                 !Join [
                   "",[
                     "#!/bin/bash -xe\n",
-                    "amazon-linux-extras enable php8.0",
-                    "yum clean metadata",
-                    "yum install php", 
+                    "amazon-linux-extras enable php8.0\n",
+                    "yum clean metadata\n",
+                    "yum -y install php\n", 
                     "if [ ! -f /etc/httpd/conf.d/", !Ref WPDirectory, ".conf ]; then\n",                    
                     "   touch /etc/httpd/conf.d/", !Ref WPDirectory, ".conf\n",
                     "   echo 'ServerName 127.0.0.1:80' >> /etc/httpd/conf.d/", !Ref WPDirectory, ".conf\n",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The web init script is bugged as there is no carriage return at the end of some lines and the yum install is missing the -y param to bypass yes/no confirmation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
